### PR TITLE
add iOS platform support to podspec

### DIFF
--- a/DictionaryCoding.podspec
+++ b/DictionaryCoding.podspec
@@ -14,9 +14,9 @@ It allows you to take a native swift class or struct that confirms to the Codabl
   s.author           = { 'Sam Deane' => 'sam@elegantchaos.com' }
   s.source           = { :git => 'https://github.com/elegantchaos/DictionaryCoding.git', :tag => s.version.to_s }
 
-  s.platform = :osx
   s.swift_version = "4.1"
   s.osx.deployment_target = "10.12"
+  s.ios.deployment_target = "10.0"
 
   s.source_files = 'Sources/DictionaryCoding/**/*'
 end


### PR DESCRIPTION
> When supporting multiple platforms you should use deployment_target below instead.

_https://guides.cocoapods.org/syntax/podspec.html#platform_