### PR TITLE
Change internal storage to NSDictionary for better performance

### DIFF
--- a/Sources/DictionaryCoding/DictionaryDecoder.swift
+++ b/Sources/DictionaryCoding/DictionaryDecoder.swift
@@ -398,7 +398,7 @@ fileprivate struct DictionaryCodingKeyedDecodingContainer<K : CodingKey> : Keyed
         #if swift(>=4.1)
         return self.container.stringKeys.compactMap { Key(stringValue: $0) }
         #else
-        return self.container.keys.flatMap { Key(stringValue: $0) }
+        return self.container.stringKeys.flatMap { Key(stringValue: $0) }
         #endif
     }
     


### PR DESCRIPTION
This change boosts decoding performance by 3x. 

If you add time spent deserializing with JSONSerialization (assuming you are starting with Data), JSONSerialization + DictionaryDecoder is now 2x faster than JSONDecoder. 

Even with this change DictionaryDecoder is still 3x slower than solutions not using Decodable, so there is still room to improve. 