### PR TITLE
Make values passthrough if they already match

### DIFF
--- a/Sources/DictionaryCoding/DictionaryDecoder.swift
+++ b/Sources/DictionaryCoding/DictionaryDecoder.swift
@@ -1321,7 +1321,9 @@ extension _DictionaryDecoder {
     }
     
     fileprivate func unbox<T : Decodable>(_ value: Any, as type: T.Type) throws -> T? {
-        if type == Date.self || type == NSDate.self {
+		if let value = value as? T {
+			return value
+		} else if type == Date.self || type == NSDate.self {
             return try self.unbox(value, as: Date.self) as? T
         } else if type == Data.self || type == NSData.self {
             return try self.unbox(value, as: Data.self) as? T


### PR DESCRIPTION
In the case where a value can be cast directly to the decoded type, we return it directly. This fixes an issue when decoding things like dates where the dictionary value is already the correct type but fails because the decoder expects a Double instead.

The tests pass but something I want to callout here that might have unneeded consequences. Many other types won't be decoded as normal. Things like `String` and `Double` will instead be returned directly. Perhaps this is a performance win?